### PR TITLE
Allow to end queries

### DIFF
--- a/schema.proto
+++ b/schema.proto
@@ -18,7 +18,8 @@ message Control {
     CLOSE = 0;
     DESTROY = 1;
   }
-  ControlCode code = 2;
+  required ControlCode code = 2;
+  required bool sentQuery = 3;
 }
 
 // type=3


### PR DESCRIPTION
Currently all queries run in live mode. If the remote ends the query stream, the end event is not transmitted. It can be useful to run non-live queries though, and to receive the end event when all messages are transferred.

I wasn't sure how exactly the Control messages are supposed to work as they don't seem to be ever sent currently? Anyway, this PR adds support for transferring the 'end' event of queries.